### PR TITLE
Updated fit(.)

### DIFF
--- a/test/test_gpfa.py
+++ b/test/test_gpfa.py
@@ -219,3 +219,13 @@ class TestGPFA(unittest.TestCase):
                                 self.z_dim, self.T[0])
         # Assert
         self.assertTrue(np.allclose(k_big_inv, full_k_big_inv))
+
+    def test_orthonormalize(self):
+        """
+        Test GPFA orthonormalize function.
+        """
+        self.gpfa.fit(self.X)
+        corth = self.gpfa.params_estimated['Corth']
+        c_orth = linalg.orth(self.gpfa.params_estimated['C'])
+        # Assert
+        self.assertTrue(np.allclose(c_orth, corth))


### PR DESCRIPTION
- Created `train_latent_seqs` stores latent seqs, etc for training data.
- Distinguish input data to be used if `use_cut_trials=True` and re-computing latent seqs on full X
- Updated docstring for `fit`
- compute orthogonalization transform once the fits are done
- Renamed `ll_cut` to `ll` in `_fitting_core` since `ll_cut` is only applicable when `cut_trials` is used.
- Renamed X (returned by `_em` in `_fitting_core`) to `latent_seqs`
- Added `latent_seqs` to returned items by `_fitting_core`
- Updated docstring for `_fitting_core`
- Added re-compute latent seqs if `use_cut_trials=True`

The docstring for the GPFA class will be updated accordingly in regards to what exactly `fit` is doing and instead of `transform` to add a docstring on `predict`