### PR TITLE
made core GPFA params into class instances

### DIFF
--- a/test/test_gpfa.py
+++ b/test/test_gpfa.py
@@ -199,6 +199,6 @@ class TestGPFA(unittest.TestCase):
         """
         pZ_mu = self.results['pZ_mu'][0]
         pZ_mu_orth = self.results['pZ_mu_orth'][0]
-        test_pZ_mu_orth = np.dot(self.gpfa.OrthTrans, pZ_mu)
+        test_pZ_mu_orth = np.dot(self.gpfa.OrthTrans_, pZ_mu)
         # Assert
         self.assertTrue(np.allclose(pZ_mu_orth, test_pZ_mu_orth))


### PR DESCRIPTION
- should we list the core GPFA class instances on line 242? For example, d_ = None, C_ = None, etc.
- _em docstring on line 509... is this still necessary? It seems like it is already captured in the above it.