### PR TITLE
Update GPFA unit tests for changed naming of GPFA latents, and varying precision across platforms

### DIFF
--- a/test/gpfa.py
+++ b/test/gpfa.py
@@ -256,8 +256,8 @@ class TestGPFA(unittest.TestCase):
         """
         test_ll = -4092.076117337763
         # Assert
-        self.assertEqual(test_ll, self.ll)
-        self.assertEqual(test_ll, self.ll_seq_kernel)
+        self.assertAlmostEqual(test_ll, self.ll)
+        self.assertAlmostEqual(test_ll, self.ll_seq_kernel)
         self.assertGreater(self.ll_multiparams_kernel, test_ll)
 
     def test_orthonormalized_transform(self):
@@ -286,4 +286,4 @@ class TestGPFA(unittest.TestCase):
         test_r2_score = 0.6648115733320232
         r2_t1 = self.gpfa.variance_explained()[0]
         # Assert
-        self.assertEqual(test_r2_score, r2_t1)
+        self.assertAlmostEqual(test_r2_score, r2_t1)


### PR DESCRIPTION
This pull request implements two changes to the GPFA unit test:
1. The unit tests have not been updated when changing the naming of GPFA latent variables from `pZ_...` to `Z_...`. This is corrected with this pull request.
2. Previously, some tests assumed precise floating-point equivalence of expected results. As this is not guaranteed by numpy across platforms, the tests have been relaxed to only expect equivalence up to a certain number of digits after the comma.