### PR TITLE
Switch back to Threading: Faster than Multiprocessing for GP optimization

### DIFF
--- a/gpfa/gpfa.py
+++ b/gpfa/gpfa.py
@@ -22,7 +22,7 @@ from sklearn.decomposition import FactorAnalysis
 from sklearn.gaussian_process.kernels import Kernel
 from sklearn.gaussian_process.kernels import RBF, WhiteKernel
 from sklearn.gaussian_process.kernels import ConstantKernel
-from concurrent.futures import ProcessPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 __all__ = [
     "GPFA"
@@ -948,7 +948,7 @@ class GPFA(sklearn.base.BaseEstimator):
             self.gp_kernel[i].theta = res_opt.x
 
         # Parallelize the optimization across dimensions
-        with ProcessPoolExecutor(
+        with ThreadPoolExecutor(
                 max_workers=min(self.max_workers, self.z_dim)
             ) as executor:
             futures = [executor.submit(_optimize_gp, i) for i in range(self.z_dim)]


### PR DESCRIPTION
Switched from ProcessPoolExecutor back to ThreadPoolExecutor after profiling showed that threading performs better for GP kernel optimization.

### Why is threading faster in this case?
1. **GIL and NumPy/SciPy Optimizations**:
   - Since SciPy's `optimize.minimize` function heavily relies on NumPy, which releases the Global Interpreter Lock (GIL) for many operations, threading allows efficient parallel execution.
   - Multiprocessing introduces overhead when pickling/unpickling data, while threading avoids this.

2. **Lower Overhead**:
   - ProcessPoolExecutor creates separate memory spaces, requiring data to be copied between processes, causing additional serialization/deserialization costs. Threading, on the other hand, shares memory, eliminating this overhead.

3. **Small Tasks Benefit More from Threads**:
   - Each GP optimization task is relatively lightweight, meaning the overhead of spawning new processes outweighs any benefits of true parallel execution.
   - Threads are better suited for tasks that involve frequent memory access and shared state, like updating kernel parameters.

4. **Less Resource Intensive**:
   - ProcessPoolExecutor may cause excessive CPU usage due to process forking, while ThreadPoolExecutor achieves parallelism without duplicating memory usage.

This change should improve performance while reducing unnecessary overhead.